### PR TITLE
Add stats_hero_sender pooled via pg2

### DIFF
--- a/src/stats_hero.app.src
+++ b/src/stats_hero.app.src
@@ -8,5 +8,5 @@
 		  stdlib
 		 ]},
   {mod, {stats_hero_app, []}},
-  {env, []}
+  {env, [{udp_socket_pool_size, 5}]}
  ]}.

--- a/src/stats_hero.erl
+++ b/src/stats_hero.erl
@@ -52,8 +52,6 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -record(state, {
-          estatsd_host           :: string(),
-          estatsd_port           :: non_neg_integer(),
           start_time             :: {non_neg_integer(), non_neg_integer(),
                                      non_neg_integer()},
           end_time               :: {non_neg_integer(), non_neg_integer(),
@@ -211,8 +209,8 @@ report_metrics(Pid, StatusCode) when is_pid(Pid), is_integer(StatusCode) ->
 
 %% @doc Start your personalized stats_hero process.
 %%
-%% `Config' is a proplist with keys: request_label, request_action, estatsd_host,
-%% estatsd_port, upstream_prefixes, my_app, org_name, and request_id.
+%% `Config' is a proplist with keys: request_label, request_action, upstream_prefixes,
+%% my_app, org_name, and request_id.
 %%
 start_link(Config) ->
     %% this server is intended to be a short-lived companion to a request process, so we
@@ -247,9 +245,7 @@ label(BadPrefix, Fun) ->
 
 init(Config) ->
     UpstreamPrefixes = ?gv(upstream_prefixes, Config),
-    State = #state{estatsd_host = ?gv(estatsd_host, Config),
-                   estatsd_port = ?gv(estatsd_port, Config),
-                   start_time = os:timestamp(),
+    State = #state{start_time = os:timestamp(),
                    my_app = as_bin(?gv(my_app, Config)),
                    my_host = hostname(),
                    request_label = as_bin(?gv(request_label, Config)),
@@ -430,15 +426,14 @@ hostname() ->
 %% TODO: make this configurable and not Opscode specific
 send_start_metrics(#state{my_app = MyApp, my_host = MyHost,
                           request_label = ReqLabel, request_action = ReqAction,
-                          org_name = OrgName,
-                          estatsd_host = EstatsdHost, estatsd_port = EstatsdPort}) ->
+                          org_name = OrgName}) ->
     Stats = [{[MyApp, ".application.byOrgName.", OrgName], 1, "m"},
              {[MyApp, ".application.allRequests"], 1, "m"},
              {[MyApp, ".", MyHost, ".allRequests"], 1, "m"},
              {[MyApp, ".application.byRequestType.", ReqLabel, ".", ReqAction], 1, "m"}
             ],
     Payload = [ make_metric_line(M) || M <- Stats ],
-    send_payload(EstatsdHost, EstatsdPort, Payload),
+    send_payload(Payload),
     ok.
 
 %% @doc This is where we package up the accumulated data and send to estatsd prior to
@@ -463,9 +458,7 @@ do_report_metrics(ReqTime, StatusCode,
                          request_action = ReqAction,
                          org_name = OrgName,
                          metrics = Metrics,
-                         upstream_prefixes = Prefixes,
-                         estatsd_host = EstatsdHost,
-                         estatsd_port = EstatsdPort}) ->
+                         upstream_prefixes = Prefixes}) ->
     StatusStr = integer_to_list(StatusCode),
     Stats = [{[MyApp, ".application.byStatusCode.", StatusStr], 1, "m"},
              {[MyApp, ".", MyHost, ".byStatusCode.", StatusStr], 1, "m"},
@@ -483,7 +476,7 @@ do_report_metrics(ReqTime, StatusCode,
                              ReqAction, ".upstreamRequests.", Upstream],
                             CTime#ctimer.time, "h"} || {Upstream, CTime} <- UpAggregates ],
     Payload = [ make_metric_line(M) || M <- Stats ++ UpstreamStats ++ UpstreamByReqStats ],
-    send_payload(EstatsdHost, EstatsdPort, Payload),
+    send_payload(Payload),
     ok.
 
 %% @doc Return a tuple list of time and count data for collected metrics.  You can control
@@ -562,15 +555,8 @@ has_prefix(P, S) ->
         _Else -> false
     end.
 
-send_payload(Server, Port, Payload) ->
-    Length = iolist_size(Payload),
-    Packet = io_lib:format("1|~B~n~s", [Length, Payload]),
-    {ok, Socket} = gen_udp:open(0),
-    try
-        ok = gen_udp:send(Socket, Server, Port, Packet)
-    after
-        gen_udp:close(Socket)
-    end.
+send_payload(Payload) ->
+    stats_hero_sender:send(Payload).
 
 %% Note this only supports integer values, but that is the only type of value currently
 %% being used.

--- a/src/stats_hero_sender.hrl
+++ b/src/stats_hero_sender.hrl
@@ -1,0 +1,1 @@
+-define(SH_SENDER_POOL, stats_hero_sender_pool).

--- a/src/stats_hero_sender_sup.erl
+++ b/src/stats_hero_sender_sup.erl
@@ -1,0 +1,36 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Seth Falcon <seth@opscode.com>
+%% @copyright 2012 Opscode, Inc.
+%% @end
+-module(stats_hero_sender_sup).
+
+-behaviour(supervisor).
+
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+-include("stats_hero_sender.hrl").
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+init([]) ->
+    {ok, SenderCount} = application:get_env(stats_hero, udp_socket_pool_size),
+    error_logger:info_msg("starting stats_hero_sender_sup with ~B senders~n", [SenderCount]),
+    ok = pg2:create(?SH_SENDER_POOL),
+    {ok, Host} = application:get_env(stats_hero, estatsd_host),
+    {ok, Port} = application:get_env(stats_hero, estatsd_port),
+    Config = [{estatsd_host, Host}, {estatsd_port, Port}, {group_name, stats_hero_sender_pool}],
+    StartUp = {stats_hero_sender, start_link, [Config]},
+    Children = [ {make_id(I), StartUp, permanent, brutal_kill, worker, [stats_hero_sender]}
+                 || I <- lists:seq(1, SenderCount) ],
+    {ok, {{one_for_one, 60, 10}, Children}}.
+
+make_id(I) ->
+    "stats_hero_sender_" ++ integer_to_list(I).

--- a/src/stats_hero_sup.erl
+++ b/src/stats_hero_sup.erl
@@ -7,7 +7,7 @@
 
 -behaviour(supervisor).
 
--define(CHILD_TYPES, [stats_hero_monitor, stats_hero_worker_sup]).
+-define(CHILD_TYPES, [stats_hero_monitor, stats_hero_worker_sup, stats_hero_sender_sup]).
 
 %% API
 -export([start_link/0]).
@@ -35,6 +35,10 @@ new_child(stats_hero_monitor, Children) ->
 new_child(stats_hero_worker_sup, Children) ->
     HeroSup = {stats_hero_worker_sup, {stats_hero_worker_sup, start_link, []}, permanent,
                brutal_kill, supervisor, [stats_hero_worker_sup]},
-    [HeroSup | Children ].
+    [HeroSup | Children ];
+new_child(stats_hero_sender_sup, Children) ->
+    SenderSup = {stats_hero_sender_sup, {stats_hero_sender_sup, start_link, []}, permanent,
+               brutal_kill, supervisor, [stats_hero_sender_sup]},
+    [SenderSup | Children ].
 
 

--- a/test/stats_hero_test.erl
+++ b/test/stats_hero_test.erl
@@ -25,13 +25,15 @@ stats_hero_integration_test_() ->
      fun() ->
              meck:new(net_adm, [passthrough, unstick]),
              meck:expect(net_adm, localhost, fun() -> "test-host" end),
-             application:start(stats_hero),
              capture_udp:start_link(0),
-              {ok, Port} = capture_udp:what_port(),
+             {ok, Port} = capture_udp:what_port(),
+             %% setup required app environment
+             application:set_env(stats_hero, estatsd_host, "localhost"),
+             application:set_env(stats_hero, estatsd_port, Port),
+             application:set_env(stats_hero, udp_socket_pool_size, 5),
+             application:start(stats_hero),
               ReqId = <<"req_id_123">>,
-              Config = [{estatsd_host, "localhost"},
-                        {estatsd_port, Port},
-                        {request_label, <<"nodes">>},
+              Config = [{request_label, <<"nodes">>},
                         {request_action, <<"PUT">>},
                         {upstream_prefixes, ?UPSTREAMS},
                         {my_app, <<"test_hero">>},
@@ -61,28 +63,6 @@ stats_hero_integration_test_() ->
      end,
      fun({ReqId, Config, Calls}) ->
               [
-               {"stats_hero_monitor keeps track of workers",
-                fun() ->
-                        ?assertEqual(1, stats_hero_monitor:registered_count()),
-                        {ok, Port} = capture_udp:what_port(),
-                        %% This is a bit gross, but we don't want this
-                        %% test to pollute our UDP capture so we guess
-                        %% the the adjacent port is unused. Since we
-                        %% are just blindly sending data to the port
-                        %% over UDP, it hopefully won't matter.
-                        Config1 = lists:keyreplace(estatsd_port, 1,
-                                                   lists:keyreplace(request_id, 1,
-                                                                    Config, {request_id, <<"temp1">>}),
-                                                   {estatsd_port, Port - 1}),
-                        stats_hero_worker_sup:new_worker(Config1),
-                        ?assertEqual(2, stats_hero_monitor:registered_count()),
-                        %% calling stop worker is async, so we sleep
-                        %% to wait for the monitor to receive and
-                        %% process the DOWN message. This is lame.
-                        stats_hero:stop_worker(<<"temp1">>),
-                        timer:sleep(100),       % LAME
-                        ?assertEqual(1, stats_hero_monitor:registered_count())
-                end},
                {"stats_hero functions give not_found or [] for a bad request id",
                 fun() ->
                         ?assertEqual(not_found,
@@ -102,11 +82,13 @@ stats_hero_integration_test_() ->
                         ?assertEqual(not_found,
                                      stats_hero:report_metrics(<<"unknown">>, 404))
                 end},
+
                {"read_alog retrieves a log message",
                 fun() ->
                         ?assertEqual([<<"hello, ">>,<<"world.">>],
                                      stats_hero:read_alog(ReqId, <<"my_log">>))
                 end},
+
                {"snapshot returns the right set of keys", generator,
                 fun() ->
                         BuildKeys = fun(K, Acc) -> expand_label(K) ++ Acc end,
@@ -141,10 +123,10 @@ stats_hero_integration_test_() ->
                         [ ?_assertEqual({Key, Count}, {Key, proplists:get_value(Key, Snapshot)})
                           || {Key, Count} <- dict:to_list(CallCounts) ]
                 end},
-               {"upd is captured",
+
+               {"udp is captured",
                 fun() ->
                         {MsgCount, Msg} = capture_udp:read(),
-                        ?assertEqual(2, MsgCount),
                         [GotStart, GotEnd] = [ parse_shp(M) || M <- Msg ],
                         ExpectStart = 
                             [{<<"test_hero.application.byOrgName.orginc">>,<<"1">>,<<"m">>},
@@ -176,10 +158,26 @@ stats_hero_integration_test_() ->
                               ?assertEqual(ELabel, GLabel),
                               ?assertEqual(EType, GType)
                           end || {{ELabel, _, EType}, {GLabel, _, GType}} <- lists:zip(ExpectEnd, GotEnd) ]
+                end},
+               %% put this test last because we don't want to include
+               %% the startup msg in UDP verification
+               {"stats_hero_monitor keeps track of workers",
+                fun() ->
+                        ?assertEqual(1, stats_hero_monitor:registered_count()),
+                        Config1 = lists:keyreplace(request_id, 1, Config,
+                                                   {request_id, <<"temp1">>}),
+                        stats_hero_worker_sup:new_worker(Config1),
+                        ?assertEqual(2, stats_hero_monitor:registered_count()),
+                        %% calling stop worker is async, so we sleep
+                        %% to wait for the monitor to receive and
+                        %% process the DOWN message. This is lame.
+                        stats_hero:stop_worker(<<"temp1">>),
+                        timer:sleep(200),       % LAME
+                        ?assertEqual(1, stats_hero_monitor:registered_count())
                 end}
               ]
-      end
-     }.
+     end
+    }.
 
 
 %% El-Cheapo Stats Hero Protocol parsing for test verification


### PR DESCRIPTION
The stats_hero_sender is a gen_server that holds onto a UDP socket for
sending metrics. This avoids churn on opening and closing the sockets.
