### PR TITLE
Add stats_hero_sender pooled via pg2

### DIFF
--- a/src/stats_hero.app.src
+++ b/src/stats_hero.app.src
@@ -8,5 +8,5 @@
 		  stdlib
 		 ]},
   {mod, {stats_hero_app, []}},
-  {env, []}
+  {env, [{udp_socket_pool_size, 5}]}
  ]}.

--- a/src/stats_hero_sender.hrl
+++ b/src/stats_hero_sender.hrl
@@ -1,0 +1,1 @@
+-define(SH_SENDER_POOL, stats_hero_sender_pool).

--- a/src/stats_hero_sender_sup.erl
+++ b/src/stats_hero_sender_sup.erl
@@ -1,0 +1,36 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Seth Falcon <seth@opscode.com>
+%% @copyright 2012 Opscode, Inc.
+%% @end
+-module(stats_hero_sender_sup).
+
+-behaviour(supervisor).
+
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+-include("stats_hero_sender.hrl").
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+init([]) ->
+    {ok, SenderCount} = application:get_env(stats_hero, udp_socket_pool_size),
+    error_logger:info_msg("starting stats_hero_sender_sup with ~B senders~n", [SenderCount]),
+    ok = pg2:create(?SH_SENDER_POOL),
+    {ok, Host} = application:get_env(stats_hero, estatsd_host),
+    {ok, Port} = application:get_env(stats_hero, estatsd_port),
+    Config = [{estatsd_host, Host}, {estatsd_port, Port}, {group_name, stats_hero_sender_pool}],
+    StartUp = {stats_hero_sender, start_link, [Config]},
+    Children = [ {make_id(I), StartUp, permanent, brutal_kill, worker, [stats_hero_sender]}
+                 || I <- lists:seq(1, SenderCount) ],
+    {ok, {{one_for_one, 60, 10}, Children}}.
+
+make_id(I) ->
+    "stats_hero_sender_" ++ integer_to_list(I).

--- a/src/stats_hero_sup.erl
+++ b/src/stats_hero_sup.erl
@@ -7,7 +7,7 @@
 
 -behaviour(supervisor).
 
--define(CHILD_TYPES, [stats_hero_monitor, stats_hero_worker_sup]).
+-define(CHILD_TYPES, [stats_hero_monitor, stats_hero_worker_sup, stats_hero_sender_sup]).
 
 %% API
 -export([start_link/0]).
@@ -35,6 +35,10 @@ new_child(stats_hero_monitor, Children) ->
 new_child(stats_hero_worker_sup, Children) ->
     HeroSup = {stats_hero_worker_sup, {stats_hero_worker_sup, start_link, []}, permanent,
                brutal_kill, supervisor, [stats_hero_worker_sup]},
-    [HeroSup | Children ].
+    [HeroSup | Children ];
+new_child(stats_hero_sender_sup, Children) ->
+    SenderSup = {stats_hero_sender_sup, {stats_hero_sender_sup, start_link, []}, permanent,
+               brutal_kill, supervisor, [stats_hero_sender_sup]},
+    [SenderSup | Children ].
 
 


### PR DESCRIPTION
The stats_hero_sender is a gen_server that holds onto a UDP socket for
sending metrics. This avoids churn on opening and closing the sockets.
