### PR TITLE
Remove per org stats from stats_hero

### DIFF
--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -54,7 +54,6 @@ using {@link stats_hero_worker_sup:new_worker/1} like this:
     Config = [{estatsd_host, EstatsdServer},
               {estatsd_port, EstatsdPort},
               {request_id, ReqId},
-              {org_name, OrgName},
               {my_app, "ChefAPI"},
               {request_label, RequestLabel},
               {request_action, atom_to_list(wrq:method(Req))},
@@ -86,11 +85,10 @@ You can retrieve call timing and count data from your `stats_hero' worker using 
 Here's the usage from `chef_rest_wm':
 
 ```
-log_request(Req, #base_state{reqid = ReqId, log_msg = Msg, organization_name = Org}) ->
+log_request(Req, #base_state{reqid = ReqId, log_msg = Msg}) ->
     Status = wrq:response_code(Req),
     Tuples = [{req_id, ReqId},
               {status, Status},
-              {org_name, Org},
               {method, wrq:method(Req)},
               {path, wrq:raw_path(Req)},
               {user, wrq:get_req_header("x-ops-userid", Req)},
@@ -123,7 +121,6 @@ worker sends the following data:
 
 ```
 1|167
-test_hero.application.byOrgName.orginc:1|m
 test_hero.application.allRequests:1|m
 test_hero.test-host.allRequests:1|m
 test_hero.application.byRequestType.nodes.PUT:1|m
@@ -134,7 +131,6 @@ When {@link stats_hero:report_metrics/2} is called the worker sends:
 1|640
 test_hero.application.byStatusCode.200:1|m
 test_hero.test-host.byStatusCode.200:1|m
-test_hero.application.byOrgName.orginc:108|h
 test_hero.application.allRequests:108|h
 test_hero.test-host.allRequests:108|h
 test_hero.application.byRequestType.nodes.PUT:108|h

--- a/src/stats_hero.erl
+++ b/src/stats_hero.erl
@@ -69,7 +69,6 @@
           my_host                :: binary(),
           request_label          :: binary(),   % roles
           request_action         :: binary(),   % update
-          org_name               :: binary(),
           request_id             :: binary(),
           metrics = dict:new()   :: dict(),
           label_fun              :: {atom(), atom()},
@@ -220,7 +219,7 @@ report_metrics(Pid, StatusCode) when is_pid(Pid), is_integer(StatusCode) ->
 %% @doc Start your personalized stats_hero process.
 %%
 %% `Config' is a proplist with keys: request_label, request_action, upstream_prefixes,
-%% my_app, org_name, and request_id.
+%% my_app, and request_id.
 %%
 start_link(Config) ->
     %% this server is intended to be a short-lived companion to a request process, so we
@@ -237,7 +236,6 @@ init(Config) ->
                    my_host = hostname(),
                    request_label = as_bin(gv(request_label, Config)),
                    request_action = as_bin(gv(request_action, Config)),
-                   org_name = atom_or_bin(gv(org_name, Config)),
                    request_id = as_bin(gv(request_id, Config)),
                    metrics = dict:new(),
                    label_fun = gv(label_fun, Config),
@@ -570,10 +568,3 @@ as_bin(X) when is_list(X) ->
     iolist_to_binary(X);
 as_bin(X) when is_binary(X) ->
     X.
-
-atom_or_bin(X) when is_atom(X);
-                    is_binary(X) ->
-    X;
-atom_or_bin(X) ->
-    as_bin(X).
-

--- a/src/stats_hero_worker_sup.erl
+++ b/src/stats_hero_worker_sup.erl
@@ -33,7 +33,7 @@
 -define(SERVER, ?MODULE).
 
 %% @doc Start a new `stats_hero' worker.  `Config' is a proplist with keys: request_label,
-%% request_action, estatsd_host, estatsd_port, upstream_prefixes, my_app, org_name, and
+%% request_action, estatsd_host, estatsd_port, upstream_prefixes, my_app, and
 %% request_id.
 %% @see stats_hero:start_link/1
 new_worker(Config) ->

--- a/test/stats_hero_test.erl
+++ b/test/stats_hero_test.erl
@@ -96,8 +96,6 @@ stats_hero_missing_required_config_test_() ->
               {request_action, <<"PUT">>},
               {upstream_prefixes, ?UPSTREAMS},
               {my_app, <<"test_hero">>},
-              %% again purposeful use of string to test conversion
-              {org_name, "orginc"},
               {label_fun, {test_util, label}},
               {request_id, <<"req_id_123">>}]
      end,
@@ -108,7 +106,7 @@ stats_hero_missing_required_config_test_() ->
      end,
      fun(FullConfig) ->
              %% These are the required keys.
-             Keys = [my_app, request_label, request_action, org_name, request_id,
+             Keys = [my_app, request_label, request_action, request_id,
                      upstream_prefixes],
              [ {"missing " ++ atom_to_list(Key),
                 fun() ->
@@ -127,7 +125,6 @@ stats_hero_integration_test_() ->
                        %% specify a config entry as a string to
                        %% exercise conversion to binary.
                        {my_app, "test_hero"},
-                       {org_name, <<"orginc">>},
                        {label_fun, {test_util, label}},
                        {request_id, <<"req_id_123">>}],
              setup_stats_hero(Config)
@@ -263,35 +260,6 @@ stats_hero_integration_test_() ->
      end
     }.
 
-stats_hero_no_org_integration_test_() ->
-    {setup,
-     fun() ->
-             ReqId = <<"req_id_123">>,
-              Config = [{request_label, <<"nodes">>},
-                        {request_action, <<"PUT">>},
-                        {upstream_prefixes, ?UPSTREAMS},
-                        {my_app, <<"test_hero">>},
-                        {org_name, unset},
-                        {label_fun, {test_util, label}},
-                        {request_id, ReqId}],
-             setup_stats_hero(Config)
-     end,
-     fun(_X) -> cleanup_stats_hero() end,
-     fun({_ReqId, _Config, _Calls}) ->
-             [
-              {"udp is captured",
-               fun() ->
-                       {_MsgCount, Msg} = capture_udp:read(),
-                       [GotStart] = [ parse_shp(M) || M <- Msg ],
-                       ExpectStart =
-                           [{<<"test_hero.application.allRequests">>,<<"1">>,<<"m">>},
-                            {<<"test_hero.test-host.allRequests">>,<<"1">>,<<"m">>},
-                            {<<"test_hero.application.byRequestType.nodes.PUT">>,<<"1">>,<<"m">>}],
-                       ?assertEqual(GotStart, ExpectStart)
-               end}
-             ]
-     end}.
-
 stats_hero_label_fun_test_() ->
     {setup,
      fun() ->
@@ -300,7 +268,6 @@ stats_hero_label_fun_test_() ->
                        {request_action, <<"PUT">>},
                        {upstream_prefixes, [<<"stats_hero_testing">>]},
                        {my_app, <<"test_hero">>},
-                       {org_name, unset},
                        {label_fun, {test_util, label}},
                        {request_id, ReqId}],
              meck:new(net_adm, [passthrough, unstick]),


### PR DESCRIPTION
Remove the stats here code that sends per org stats, since they are not used and are eating up space on the graphite box.

It is not clear to me if the org_name should also be used from the base state or it that still has value, so that is left in for now (I figured some modules using stats_hero must still send it).

Also not sure the best way to test this. Is there a recommended dev-vm setup to try?

@seth and anyone else interested.
