### PR TITLE
support for erlang 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The `stats_hero` application can help you instrument your Erlang
 application with metrics that will be reported to `estatsd` and
 browsable in Graphite.
 
-
 ### <a name="How_to_instrument_your_code_to_collect_metrics">How to instrument your code to collect metrics</a> ###
 
 Include the `stats_hero.hrl` file. Wrap calls to upstream services

--- a/rebar.config
+++ b/rebar.config
@@ -18,3 +18,7 @@
 	     {top_level_readme,
               {"./README.md",
                "http://github.com/opscode/stats_hero"}}]}.
+
+{erl_opts, [
+  {platform_define, "^[0-9]+", namespaced_types}
+]}.

--- a/src/stats_hero.erl
+++ b/src/stats_hero.erl
@@ -63,6 +63,11 @@
 
 -include("stats_hero.hrl").
 
+-ifdef(namespaced_types).
+-type dict() :: dict:dict().
+-endif.
+
+
 -record(state, {
           start_time             :: {non_neg_integer(), non_neg_integer(),
                                      non_neg_integer()},


### PR DESCRIPTION
kills the following warnings:

```
src/stats_hero.erl:82: Warning: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/stats_hero.erl:414: Warning: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/stats_hero.erl:437: Warning: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/stats_hero.erl:437: Warning: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
```

as long as this

```erlang
{erl_opts, [
  {d, namespaced_types}
]}.
```

is in your `rebar.config`. I learned that trick from sqerl