### PR TITLE
Upgrade to Erlang 24.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: erlang
 otp_release:
+  - 25.0
+  - 24.3
   - 21.0
   - 20.3
   - 19.3

--- a/rebar.config
+++ b/rebar.config
@@ -4,12 +4,12 @@
 {deps, [
 
         {meck, ".*",
-         {git, "git://github.com/eproxus/meck.git", {branch, "master"}}},
+         {git, "https://github.com/eproxus/meck", {ref, "06192a984750070ace33b60a492ca27ec9bc6806"}}},
 
         {edown, ".*",
-         {git, "git://github.com/uwiger/edown.git", {branch, "master"}}},
+         {git, "https://github.com/uwiger/edown", {ref, "3c4f660c892e395fedac83b43476b23d38f4efb4"}}},
         {envy, ".*",
-         {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
+         {git, "https://github.com/manderson26/envy", {branch, "master"}}}
         ]}.
 
 {cover_enabled, true}.

--- a/src/stats_hero_sender_sup.erl
+++ b/src/stats_hero_sender_sup.erl
@@ -31,7 +31,7 @@
 -export([init/1]).
 
 -define(SERVER, ?MODULE).
--include("stats_hero_sender.hrl").
+
 
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
@@ -39,7 +39,7 @@ start_link() ->
 init([]) ->
     SenderCount = envy:get(stats_hero, udp_socket_pool_size, pos_integer),
     error_logger:info_msg("starting stats_hero_sender_sup with ~B senders~n", [SenderCount]),
-    ok = pg2:create(?SH_SENDER_POOL),
+
     Host = envy:get(stats_hero, estatsd_host, string),
     Port = envy:get(stats_hero, estatsd_port, pos_integer),
     Config = [{estatsd_host, Host}, {estatsd_port, Port}, {group_name, stats_hero_sender_pool}],

--- a/src/stats_hero_sup.erl
+++ b/src/stats_hero_sup.erl
@@ -23,7 +23,7 @@
 
 -behaviour(supervisor).
 
--define(CHILD_TYPES, [stats_hero_monitor, stats_hero_worker_sup, stats_hero_sender_sup]).
+-define(CHILD_TYPES, [stats_hero_monitor, stats_hero_worker_sup, stats_hero_sender_sup, pg]).
 
 %% API
 -export([start_link/0]).
@@ -54,7 +54,9 @@ new_child(stats_hero_worker_sup, Children) ->
     [HeroSup | Children ];
 new_child(stats_hero_sender_sup, Children) ->
     SenderSup = {stats_hero_sender_sup, {stats_hero_sender_sup, start_link, []}, permanent,
-               brutal_kill, supervisor, [stats_hero_sender_sup]},
-    [SenderSup | Children ].
-
-
+                 brutal_kill, supervisor, [stats_hero_sender_sup]},
+    [SenderSup | Children ];
+new_child(pg, Children) ->
+    PG = {pg, {pg, start_link, []}, permanent,
+               brutal_kill, worker, [pg]},
+    [PG | Children ].


### PR DESCRIPTION
@mp may want to provide slightly more than a cursory glance, as this was a little more extensive than most other fixes and less straightforward, and the path forward wasn't exactly known (see commit "replacing pg2 with pg").  Having said that, it seems to work.

```
mac:stats_hero lbaker$ ~/chef-server/src/bookshelf/rebar3 compile
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling stats_hero
mac:stats_hero lbaker$
```